### PR TITLE
side_filter and column_defs auto-generation toggles to data_table

### DIFF
--- a/ecodev_front/tables/data_table.py
+++ b/ecodev_front/tables/data_table.py
@@ -44,13 +44,23 @@ def data_table(id: str | dict,
                tree_table: bool = False,
                floating_filter: bool = False,
                wrap_text: bool = False,
-               theme: str = 'ag-theme-quartz'
+               theme: str = 'ag-theme-quartz',
+               side_filter: bool = False,
+               autogenerate_column_defs: bool = True,
                ) -> dag.AgGrid:
     """
     Generic Dash AG Grid table
+
+    Args:
+        side_filter (bool) : if True, adds a side bar with filtering options. Filters \
+            will be generated for columns according to the config in column_defs. Overwrites
+            the sidebar key in dash_grid_options
+        autogenerate_column_defs (bool) : if True, creates column_defs from row_data if \
+            column_defs is not provided. Defaults to True.
     """
 
-    column_defs = column_defs or _create_default_column_definitions(row_data)
+    column_defs = column_defs or _create_default_column_definitions(
+        row_data) if autogenerate_column_defs else []
     style = style
     default_col_def = default_col_def or {
         # enable floating filters by default
@@ -70,6 +80,9 @@ def data_table(id: str | dict,
         'pagination': pagination,
         'paginationPageSize': pagination_page_size,
     }
+
+    if side_filter:
+        dash_grid_options['sideBar'] = 'filters'
 
     if tree_table:
         dash_grid_options |= {'autoGroupColumnDef': {


### PR DESCRIPTION
Added bool params to control the addition of side_filter to data_table and column_defs auto-generation

**Type of change**
- [x] Feature
- [] Bugfix
- [] Refactoring
- [] Documentation

-----------------------

**Context**

>_What does this PR implement and how? What are the requirements?_
Added bool param to add side_filter to dash ag-grid table
Added bool param to add control the auto-generation of column definitions from row_data.

>_Why is this change needed? Related issue #?_
 This change is necessary to be able to show tree data in dash ag-grid without any extra attributes (i.e., just show the groups column). This allows column_defs to default to []

>_Any diagrams or screenshot to help reviewers?_

>_Please describe the tests you have performed to ensure the feature or fix are robust & effective?_


Your comments


-----------------------

**What should the reviewer focus on?**
>_Do you have specific questions/ areas for the reviewer?_

>_Which alternative solutions have you already considered and why did you not implement it?_

>_Where is the highest risk/ most complicated change that the reviewer should focus on?_

>_Is there a specific code review topic the reviewer should focus on (e.g., correct error handling, API usage)_

>_What is a good place to start the review (e.g., specific file/method?)_


Your comments


-----------------------

**For reviewer:**

[PR Review guidelines](https://google.github.io/eng-practices/review/reviewer/standard.html)
