### PR TITLE
Update further_info.py

### DIFF
--- a/ecodev_front/further_info.py
+++ b/ecodev_front/further_info.py
@@ -2,22 +2,30 @@ import dash_mantine_components as dmc
 from dash_iconify import DashIconify
 
 
-def further_info(info: str | list[dmc.Text], large: bool = False) -> dmc.Tooltip:
+def further_info(
+    info: str | list[dmc.Text], 
+    large: bool = False, 
+    **kwargs
+) -> dmc.Tooltip:
     """
     Renders a gray info icon which opens the further info tooltip.
     """
+    kwargs.setdefault("position", "top-right")
+    kwargs.setdefault("multiline", True)
+    kwargs.setdefault("offset", 3)
+    kwargs.setdefault("radius", "md")
+    kwargs.setdefault("closeDelay", 300)
+    kwargs.setdefault("color", "white")
+    kwargs.setdefault("style", {"max-width": 500, "border": "1px solid #dcdcdc"})
+
     return dmc.Tooltip(
-        label=info,
-        position='top-right',
-        multiline=True,
-        offset=3,
-        radius='md',
-        color='white',
-        style={'max-width': 500, 'border': '1px solid #dcdcdc'},
-        closeDelay=300,
+        label=dmc.Text(info, c='black') if isinstance(info, str) else info,
         children=[
-            DashIconify(icon='material-symbols:info-outline-rounded',
-                        color='gray',
-                        width=28 if large else 22)
-        ]
+            DashIconify(
+                icon="material-symbols:info-outline-rounded",
+                color="gray",
+                width=28 if large else 22,
+            )
+        ],
+        **kwargs
     )

--- a/ecodev_front/further_info.py
+++ b/ecodev_front/further_info.py
@@ -5,18 +5,18 @@ from dash_iconify import DashIconify
 def further_info(
     info: str | list[dmc.Text], 
     large: bool = False, 
+    position: str = "top-right",
+    multiline: bool= True,
+    offset: int=3,
+    radius: str= "md",
+    closeDelay: int = 300,
+    color: str = "white",
+    style: dict = {"max-width": 500, "border": "1px solid #dcdcdc"},
     **kwargs
 ) -> dmc.Tooltip:
     """
     Renders a gray info icon which opens the further info tooltip.
     """
-    kwargs.setdefault("position", "top-right")
-    kwargs.setdefault("multiline", True)
-    kwargs.setdefault("offset", 3)
-    kwargs.setdefault("radius", "md")
-    kwargs.setdefault("closeDelay", 300)
-    kwargs.setdefault("color", "white")
-    kwargs.setdefault("style", {"max-width": 500, "border": "1px solid #dcdcdc"})
 
     return dmc.Tooltip(
         label=dmc.Text(info, c='black') if isinstance(info, str) else info,
@@ -27,5 +27,12 @@ def further_info(
                 width=28 if large else 22,
             )
         ],
+        position=position,
+        multiline=multiline,
+        offset=offset,
+        radius=radius,
+        closeDelay=closeDelay,
+        color=color,
+        style=style,
         **kwargs
     )


### PR DESCRIPTION
add kwargs to tooltip. It is in particular useful when willing to change text color : it is white with a white background by default : 

<img width="542" height="102" alt="Capture d’écran 2025-07-16 à 09 43 05" src="https://github.com/user-attachments/assets/64c399ba-bda8-4ec8-ba37-6c98775d0a40" />
