### PR TITLE
Add get_row_id arg to data_table

### DIFF
--- a/ecodev_front/tables/data_table.py
+++ b/ecodev_front/tables/data_table.py
@@ -55,6 +55,7 @@ def data_table(id: str | dict,
                hide_empty_cols: bool = False,
                empty_cols_to_show: list[str] = [],
                get_row_id: Optional[str] = None,
+               **kwargs,
                ) -> dag.AgGrid:
     """
     Generic Dash AG Grid table
@@ -146,6 +147,7 @@ def data_table(id: str | dict,
         dashGridOptions=dash_grid_options,
         className=theme,
         getRowId=get_row_id,
+        **kwargs,
     )
 
 


### PR DESCRIPTION
**Type of change**
- [x] Feature
- [] Bugfix
- [] Refactoring
- [] Documentation

-----------------------

**Context**

>_What does this PR implement and how? What are the requirements?
Allow to pass values to getRowId arg of `dag.AgGrid` when using `data_table`. to assign the `RowID` of each row in row_data from the table's data. Ex : "params.data.id" to assign it to "id" field. See https://dash.plotly.com/dash-ag-grid/row-ids for more information.

>_Why is this change needed? Related issue #?_
To link data_table rows to database rows without the use of hidden ID cols

>_Please describe the tests you have performed to ensure the feature or fix are robust & effective?_
Made sure that passing null does not break `dag.AgGrid`

Your comments


-----------------------

**What should the reviewer focus on?**
>_Which alternative solutions have you already considered and why did you not implement it?_
using a hidden id col adds extra overhead.

>_Where is the highest risk/ most complicated change that the reviewer should focus on?_
Breaking existing usage of `dag.AgGrid`



Your comments


-----------------------

**For reviewer:**

[PR Review guidelines](https://google.github.io/eng-practices/review/reviewer/standard.html)
